### PR TITLE
Fix token API endpoint file and add unit test

### DIFF
--- a/src/Tests/test_token_api_endpoints.py
+++ b/src/Tests/test_token_api_endpoints.py
@@ -1,0 +1,25 @@
+import types
+from token_api_endpoints import register_token_api_endpoints
+
+class DummyApp:
+    def __init__(self):
+        self.routes = []
+    def route(self, route: str, methods: list[str]):
+        def decorator(func):
+            self.routes.append((route, tuple(methods), func))
+            return func
+        return decorator
+
+
+def test_register_token_api_endpoints():
+    app = DummyApp()
+    register_token_api_endpoints(app)
+    # Expect four routes to be registered
+    routes = {r for r, _m, _f in app.routes}
+    expected = {
+        "tokens/{scope}",
+        "tokens",
+        "tokens/health",
+        "tokens/refresh/{scope}",
+    }
+    assert expected.issubset(routes)

--- a/src/token_api_endpoints.py
+++ b/src/token_api_endpoints.py
@@ -10,6 +10,7 @@ import logging
 from datetime import datetime
 
 import azure.functions as func
+
 from mcp_redis_config import get_redis_token_manager
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- fix trailing prompt artifact in `token_api_endpoints.py`
- ensure imports are sorted
- add unit test covering token API endpoint registration

## Testing
- `ruff check src/token_api_endpoints.py`
- `PYTHONPATH=src pytest src/Tests/test_token_api_endpoints.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684600c195948324a52efbb7178a4dc2